### PR TITLE
Append to bashrc instead of overwriting it

### DIFF
--- a/security/thehotwalletexposure/.init
+++ b/security/thehotwalletexposure/.init
@@ -33,7 +33,7 @@ chmod 644 /home/hacker/.hidden_env_vars
 chown hacker:hacker /home/hacker/.hidden_env_vars
 
 # Create .bashrc that sources the environment variables
-cat > /home/hacker/.bashrc << 'EOF'
+cat >> /home/hacker/.bashrc << 'EOF'
 # Challenge 2 Setup - Source environment variables
 source /home/hacker/.hidden_env_vars
 EOF


### PR DESCRIPTION
I had an existing .bashrc that was overwritten when I launched this challenge, I was able to recover it from the VSCode edit timeline but I believe this should be safer in the future.